### PR TITLE
Replace zap with logrus and add TenantHook for req identification

### DIFF
--- a/gatekeeper/doc.go
+++ b/gatekeeper/doc.go
@@ -347,6 +347,9 @@ type Config struct {
 
 	// DisableAllLogging indicates no logging at all
 	DisableAllLogging bool `json:"disable-all-logging" yaml:"disable-all-logging" usage:"disables all logging to stdout and stderr"`
+
+	// TenantID corresponds to the realm used in the discovery url for oidc provider configuration retrieval
+	TenantID string
 }
 
 // getVersion returns the proxy version

--- a/gatekeeper/logger.go
+++ b/gatekeeper/logger.go
@@ -14,12 +14,12 @@ type TenantHook struct {
 	tenantID string
 }
 
-// Levels returns all levels the hook is activate on
+// Levels returns a logrus.Level slice containing all levels the hook is fired on
 func (h *TenantHook) Levels() []logrus.Level {
 	return logrus.AllLevels
 }
 
-// Fire is trigger on log execution
+// Fire is the trigger in which Hook logic lives and is executed upon log entry
 func (h *TenantHook) Fire(e *logrus.Entry) error {
 	e.Data["tenant"] = h.tenantID
 	return nil

--- a/gatekeeper/logger.go
+++ b/gatekeeper/logger.go
@@ -11,7 +11,7 @@ import (
 
 // TenantHook adds the tenantID to each log entry
 type TenantHook struct {
-	TenantID string
+	tenantID string
 }
 
 // Levels returns all levels the hook is activate on
@@ -21,7 +21,7 @@ func (h *TenantHook) Levels() []logrus.Level {
 
 // Fire is trigger on log execution
 func (h *TenantHook) Fire(e *logrus.Entry) error {
-	e.Data["tenantID"] = h.TenantID
+	e.Data["tenant"] = h.tenantID
 	return nil
 }
 
@@ -36,8 +36,7 @@ func createLogger(config *Config) *logrus.Logger {
 		Level:     logrus.DebugLevel,
 	}
 
-	// Add the TenantID as a field on Config
-	logger.AddHook(&TenantHook{TenantID: "myTenantID"})
+	logger.AddHook(&TenantHook{tenantID: config.TenantID})
 
 	if config.DisableAllLogging {
 		logger.SetOutput(ioutil.Discard)

--- a/gatekeeper/logger.go
+++ b/gatekeeper/logger.go
@@ -1,0 +1,65 @@
+package gatekeeper
+
+import (
+	"io/ioutil"
+	httplog "log"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// TenantHook adds the tenantID to each log entry
+type TenantHook struct {
+	TenantID string
+}
+
+// Levels returns all levels the hook is activate on
+func (h *TenantHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// Fire is trigger on log execution
+func (h *TenantHook) Fire(e *logrus.Entry) error {
+	e.Data["tenantID"] = h.TenantID
+	return nil
+}
+
+// createLogger is responsible for creating the service logger
+func createLogger(config *Config) *logrus.Logger {
+	httplog.SetOutput(ioutil.Discard) // disable the http logger
+
+	logger := &logrus.Logger{
+		Out:       os.Stdout,
+		Formatter: newTextFormatter(),
+		Hooks:     make(logrus.LevelHooks),
+		Level:     logrus.DebugLevel,
+	}
+
+	// Add the TenantID as a field on Config
+	logger.AddHook(&TenantHook{TenantID: "myTenantID"})
+
+	if config.DisableAllLogging {
+		logger.SetOutput(ioutil.Discard)
+	}
+
+	if config.Verbose {
+		logger.Level = logrus.TraceLevel
+	}
+
+	return logger
+}
+
+func newJSONFormatter() *logrus.JSONFormatter {
+	return &logrus.JSONFormatter{
+		TimestampFormat: time.RFC3339Nano,
+	}
+}
+
+func newTextFormatter() *logrus.TextFormatter {
+	return &logrus.TextFormatter{
+		DisableColors:   true,
+		FullTimestamp:   true,
+		TimestampFormat: time.RFC3339Nano,
+	}
+}

--- a/gatekeeper/middleware.go
+++ b/gatekeeper/middleware.go
@@ -236,7 +236,7 @@ func (r *OAuthProxy) checkClaim(user *userContext, claimName string, match *rege
 	}
 
 	if _, found := user.claims[claimName]; !found {
-		r.log.Warn("the token does not have the claim", errFields...)
+		r.log.Warn("the token does not have the claim", errFields)
 		return false
 	}
 
@@ -250,7 +250,7 @@ func (r *OAuthProxy) checkClaim(user *userContext, claimName string, match *rege
 		r.log.Warn("claim requirement does not match claim in token", append(errFields,
 			zap.String("issued", valueStr),
 			zap.String("required", match.String()),
-		)...)
+		))
 
 		return false
 	}
@@ -267,7 +267,7 @@ func (r *OAuthProxy) checkClaim(user *userContext, claimName string, match *rege
 		r.log.Warn("claim requirement does not match any element claim group in token", append(errFields,
 			zap.String("issued", fmt.Sprintf("%v", valueStrs)),
 			zap.String("required", match.String()),
-		)...)
+		))
 
 		return false
 	}
@@ -277,11 +277,11 @@ func (r *OAuthProxy) checkClaim(user *userContext, claimName string, match *rege
 		r.log.Error("unable to extract the claim from token (tried string and strings)", append(errFields,
 			zap.Error(errStr),
 			zap.Error(errStrs),
-		)...)
+		))
 		return false
 	}
 
-	r.log.Warn("unexpected error", errFields...)
+	r.log.Warn("unexpected error", errFields)
 	return false
 }
 

--- a/gatekeeper/middleware.go
+++ b/gatekeeper/middleware.go
@@ -27,9 +27,8 @@ import (
 	"github.com/gambol99/go-oidc/jose"
 	"github.com/go-chi/chi/middleware"
 	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
 	"github.com/unrolled/secure"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -87,13 +86,14 @@ func (r *OAuthProxy) loggingMiddleware(next http.Handler) http.Handler {
 		resp := w.(middleware.WrapResponseWriter)
 		next.ServeHTTP(resp, req)
 		addr := req.RemoteAddr
-		r.log.Info("client request",
-			zap.Duration("latency", time.Since(start)),
-			zap.Int("status", resp.Status()),
-			zap.Int("bytes", resp.BytesWritten()),
-			zap.String("client_ip", addr),
-			zap.String("method", req.Method),
-			zap.String("path", req.URL.Path))
+		r.log.WithFields(logrus.Fields{
+			"latency":   time.Since(start),
+			"status":    resp.Status(),
+			"bytes":     resp.BytesWritten(),
+			"client_ip": addr,
+			"method":    req.Method,
+			"path":      req.URL.Path,
+		}).Info("client request")
 	})
 }
 
@@ -105,7 +105,7 @@ func (r *OAuthProxy) authenticationMiddleware(resource *Resource) func(http.Hand
 			// grab the user identity from the request
 			user, err := r.getIdentity(req)
 			if err != nil {
-				r.log.Error("no session found in request, redirecting for authorization", zap.Error(err))
+				r.log.WithError(err).Error("no session found in request, redirecting for authorization")
 				next.ServeHTTP(w, req.WithContext(r.redirectToAuthorization(w, req)))
 				return
 			}
@@ -118,10 +118,11 @@ func (r *OAuthProxy) authenticationMiddleware(resource *Resource) func(http.Hand
 			if r.config.SkipTokenVerification {
 				r.log.Warn("skip token verification enabled, skipping verification - TESTING ONLY")
 				if user.isExpired() {
-					r.log.Error("the session has expired and verification switch off",
-						zap.String("client_ip", clientIP),
-						zap.String("username", user.name),
-						zap.String("expired_on", user.expiresAt.String()))
+					r.log.WithFields(logrus.Fields{
+						"client_ip":  clientIP,
+						"username":   user.name,
+						"expired_on": user.expiresAt.String(),
+					}).Error("the session has expired and verification switch off")
 
 					next.ServeHTTP(w, req.WithContext(r.redirectToAuthorization(w, req)))
 					return
@@ -132,9 +133,10 @@ func (r *OAuthProxy) authenticationMiddleware(resource *Resource) func(http.Hand
 					// expired error we immediately throw an access forbidden - as there is
 					// something messed up in the token
 					if err != ErrAccessTokenExpired {
-						r.log.Error("access token failed verification",
-							zap.String("client_ip", clientIP),
-							zap.Error(err))
+						r.log.WithFields(logrus.Fields{
+							"client_ip": clientIP,
+							"error":     err,
+						}).Error("access token failed verification")
 
 						next.ServeHTTP(w, req.WithContext(r.accessForbidden(w, req)))
 						return
@@ -142,26 +144,29 @@ func (r *OAuthProxy) authenticationMiddleware(resource *Resource) func(http.Hand
 
 					// step: check if we are refreshing the access tokens and if not re-auth
 					if !r.config.EnableRefreshTokens {
-						r.log.Error("session expired and access token refreshing is disabled",
-							zap.String("client_ip", clientIP),
-							zap.String("email", user.name),
-							zap.String("expired_on", user.expiresAt.String()))
+						r.log.WithFields(logrus.Fields{
+							"client_ip":  clientIP,
+							"email":      user.name,
+							"expired_on": user.expiresAt.String(),
+						}).Error("session expired and access token refreshing is disabled")
 
 						next.ServeHTTP(w, req.WithContext(r.redirectToAuthorization(w, req)))
 						return
 					}
 
-					r.log.Info("accces token for user has expired, attemping to refresh the token",
-						zap.String("client_ip", clientIP),
-						zap.String("email", user.email))
+					r.log.WithFields(logrus.Fields{
+						"client_ip": clientIP,
+						"email":     user.email,
+					}).Info("accces token for user has expired, attemping to refresh the token")
 
 					// step: check if the user has refresh token
 					refresh, encrypted, err := r.retrieveRefreshToken(req.WithContext(ctx), user)
 					if err != nil {
-						r.log.Error("unable to find a refresh token for user",
-							zap.String("client_ip", clientIP),
-							zap.String("email", user.email),
-							zap.Error(err))
+						r.log.WithFields(logrus.Fields{
+							"client_ip": clientIP,
+							"email":     user.email,
+							"error":     err,
+						}).Error("unable to find a refresh token for user")
 
 						next.ServeHTTP(w, req.WithContext(r.redirectToAuthorization(w, req)))
 						return
@@ -172,13 +177,14 @@ func (r *OAuthProxy) authenticationMiddleware(resource *Resource) func(http.Hand
 					if err != nil {
 						switch err {
 						case ErrRefreshTokenExpired:
-							r.log.Warn("refresh token has expired, cannot retrieve access token",
-								zap.String("client_ip", clientIP),
-								zap.String("email", user.email))
+							r.log.WithFields(logrus.Fields{
+								"client_ip": clientIP,
+								"email":     user.email,
+							}).Warn("refresh token has expired, cannot retrieve access token")
 
 							r.clearAllCookies(req.WithContext(ctx), w)
 						default:
-							r.log.Error("failed to refresh the access token", zap.Error(err))
+							r.log.WithError(err).Error("failed to refresh the access token")
 						}
 						next.ServeHTTP(w, req.WithContext(r.redirectToAuthorization(w, req)))
 
@@ -187,16 +193,17 @@ func (r *OAuthProxy) authenticationMiddleware(resource *Resource) func(http.Hand
 					// get the expiration of the new access token
 					expiresIn := r.getAccessCookieExpiration(token, refresh)
 
-					r.log.Info("injecting the refreshed access token cookie",
-						zap.String("client_ip", clientIP),
-						zap.String("cookie_name", r.config.CookieAccessName),
-						zap.String("email", user.email),
-						zap.Duration("expires_in", time.Until(exp)))
+					r.log.WithFields(logrus.Fields{
+						"client_ip":   clientIP,
+						"cookie_name": r.config.CookieAccessName,
+						"email":       user.email,
+						"expires_in":  time.Until(exp),
+					}).Info("injecting the refreshed access token cookie")
 
 					accessToken := token.Encode()
 					if r.config.EnableEncryptedToken {
 						if accessToken, err = encodeText(accessToken, r.config.EncryptionKey); err != nil {
-							r.log.Error("unable to encode the access token", zap.Error(err))
+							r.log.WithError(err).Error("unable to encode the access token")
 							w.WriteHeader(http.StatusInternalServerError)
 							return
 						}
@@ -207,10 +214,10 @@ func (r *OAuthProxy) authenticationMiddleware(resource *Resource) func(http.Hand
 					if r.useStore() {
 						go func(old, new jose.JWT, encrypted string) {
 							if err := r.DeleteRefreshToken(old); err != nil {
-								r.log.Error("failed to remove old token", zap.Error(err))
+								r.log.WithError(err).Error("failed to remove old token")
 							}
 							if err := r.StoreRefreshToken(new, encrypted); err != nil {
-								r.log.Error("failed to store refresh token", zap.Error(err))
+								r.log.WithError(err).Error("failed to store refresh token")
 								return
 							}
 						}(user.token, token, encrypted)
@@ -228,15 +235,13 @@ func (r *OAuthProxy) authenticationMiddleware(resource *Resource) func(http.Hand
 
 // checkClaim checks whether claim in userContext matches claimName, match. It can be String or Strings claim.
 func (r *OAuthProxy) checkClaim(user *userContext, claimName string, match *regexp.Regexp, resourceURL string) bool {
-	errFields := []zapcore.Field{
-		zap.String("claim", claimName),
-		zap.String("access", "denied"),
-		zap.String("email", user.email),
-		zap.String("resource", resourceURL),
-	}
-
 	if _, found := user.claims[claimName]; !found {
-		r.log.Warn("the token does not have the claim", errFields)
+		r.log.WithFields(logrus.Fields{
+			"claim":    claimName,
+			"access":   "denied",
+			"email":    user.email,
+			"resource": resourceURL,
+		}).Warn("the token does not have the claim")
 		return false
 	}
 
@@ -247,10 +252,14 @@ func (r *OAuthProxy) checkClaim(user *userContext, claimName string, match *rege
 		if match.MatchString(valueStr) {
 			return true
 		}
-		r.log.Warn("claim requirement does not match claim in token", append(errFields,
-			zap.String("issued", valueStr),
-			zap.String("required", match.String()),
-		))
+		r.log.WithFields(logrus.Fields{
+			"claim":    claimName,
+			"access":   "denied",
+			"email":    user.email,
+			"resource": resourceURL,
+			"issued":   valueStr,
+			"required": match.String(),
+		}).Warn("claim requirement does not match claim in token")
 
 		return false
 	}
@@ -264,24 +273,37 @@ func (r *OAuthProxy) checkClaim(user *userContext, claimName string, match *rege
 				return true
 			}
 		}
-		r.log.Warn("claim requirement does not match any element claim group in token", append(errFields,
-			zap.String("issued", fmt.Sprintf("%v", valueStrs)),
-			zap.String("required", match.String()),
-		))
+		r.log.WithFields(logrus.Fields{
+			"claim":    claimName,
+			"access":   "denied",
+			"email":    user.email,
+			"resource": resourceURL,
+			"issued":   valueStr,
+			"required": match.String(),
+		}).Warn("claim requirement does not match any element claim group in token")
 
 		return false
 	}
 
 	// If this fails, the claim is probably float or int.
 	if errStr != nil && errStrs != nil {
-		r.log.Error("unable to extract the claim from token (tried string and strings)", append(errFields,
-			zap.Error(errStr),
-			zap.Error(errStrs),
-		))
+		r.log.WithFields(logrus.Fields{
+			"claim":    claimName,
+			"access":   "denied",
+			"email":    user.email,
+			"resource": resourceURL,
+			"errStr":   errStr,
+			"errStrs":  errStrs,
+		}).Error("unable to extract the claim from token (tried string and strings)")
 		return false
 	}
 
-	r.log.Warn("unexpected error", errFields)
+	r.log.WithFields(logrus.Fields{
+		"claim":    claimName,
+		"access":   "denied",
+		"email":    user.email,
+		"resource": resourceURL,
+	}).Warn("unexpected error")
 	return false
 }
 
@@ -304,11 +326,12 @@ func (r *OAuthProxy) admissionMiddleware(resource *Resource) func(http.Handler) 
 
 			// @step: we need to check the roles
 			if !hasAccess(resource.Roles, user.roles, !resource.RequireAnyRole) {
-				r.log.Warn("access denied, invalid roles",
-					zap.String("access", "denied"),
-					zap.String("email", user.email),
-					zap.String("resource", resource.URL),
-					zap.String("roles", resource.getRoles()))
+				r.log.WithFields(logrus.Fields{
+					"access":   "denied",
+					"email":    user.email,
+					"resource": resource.URL,
+					"roles":    resource.getRoles(),
+				}).Warn("access denied, invalid roles")
 
 				next.ServeHTTP(w, req.WithContext(r.accessForbidden(w, req)))
 				return
@@ -316,11 +339,12 @@ func (r *OAuthProxy) admissionMiddleware(resource *Resource) func(http.Handler) 
 
 			// @step: check if we have any groups, the groups are there
 			if !hasAccess(resource.Groups, user.groups, false) {
-				r.log.Warn("access denied, invalid roles",
-					zap.String("access", "denied"),
-					zap.String("email", user.email),
-					zap.String("resource", resource.URL),
-					zap.String("groups", strings.Join(resource.Groups, ",")))
+				r.log.WithFields(logrus.Fields{
+					"access":   "denied",
+					"email":    user.email,
+					"resource": resource.URL,
+					"groups":   strings.Join(resource.Groups, ","),
+				}).Warn("access denied, invalid roles")
 
 				next.ServeHTTP(w, req.WithContext(r.accessForbidden(w, req)))
 				return
@@ -334,11 +358,12 @@ func (r *OAuthProxy) admissionMiddleware(resource *Resource) func(http.Handler) 
 				}
 			}
 
-			r.log.Debug("access permitted to resource",
-				zap.String("access", "permitted"),
-				zap.String("email", user.email),
-				zap.Duration("expires", time.Until(user.expiresAt)),
-				zap.String("resource", resource.URL))
+			r.log.WithFields(logrus.Fields{
+				"access":   "permitted",
+				"email":    user.email,
+				"expires":  time.Until(user.expiresAt),
+				"resource": resource.URL,
+			}).Debug("access permitted to resource")
 
 			next.ServeHTTP(w, req)
 		})
@@ -422,7 +447,7 @@ func (r *OAuthProxy) securityMiddleware(next http.Handler) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if err := secure.Process(w, req); err != nil {
-			r.log.Warn("failed security middleware", zap.Error(err))
+			r.log.WithError(err).Warn("failed security middleware")
 			next.ServeHTTP(w, req.WithContext(r.accessForbidden(w, req)))
 			return
 		}

--- a/gatekeeper/misc.go
+++ b/gatekeeper/misc.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/gambol99/go-oidc/jose"
-	"go.uber.org/zap"
 )
 
 // filterCookies is responsible for censoring any cookies we don't want sent
@@ -75,7 +74,7 @@ func (r *OAuthProxy) accessForbidden(w http.ResponseWriter, req *http.Request) c
 	if r.config.hasCustomForbiddenPage() {
 		name := path.Base(r.config.ForbiddenPage)
 		if err := r.Render(w, name, r.config.Tags); err != nil {
-			r.log.Error("failed to render the template", zap.Error(err), zap.String("template", name))
+			r.log.WithField("template", name).WithError(err).Error("failed to render the template")
 		}
 	}
 

--- a/gatekeeper/rotation.go
+++ b/gatekeeper/rotation.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/sirupsen/logrus"
 	"go.uber.org/zap"
 )
 
@@ -34,11 +35,11 @@ type certificationRotation struct {
 	// the privateKeyFile is the path of the private key
 	privateKeyFile string
 	// the logger for this service
-	log *zap.Logger
+	log *logrus.Logger
 }
 
 // newCertificateRotator creates a new certificate
-func newCertificateRotator(cert, key string, log *zap.Logger) (*certificationRotation, error) {
+func newCertificateRotator(cert, key string, log *logrus.Logger) (*certificationRotation, error) {
 	// step: attempt to load the certificate
 	certificate, err := tls.LoadX509KeyPair(cert, key)
 	if err != nil {

--- a/gatekeeper/self_signed.go
+++ b/gatekeeper/self_signed.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"go.uber.org/zap"
 )
 
@@ -39,13 +40,13 @@ type selfSignedCertificate struct {
 	// privateKey is the rsa private key
 	privateKey *rsa.PrivateKey
 	// the logger for this service
-	log *zap.Logger
+	log *logrus.Logger
 	// stopCh is a channel to close off the rotation
 	cancel context.CancelFunc
 }
 
 // newSelfSignedCertificate creates and returns a self signed certificate manager
-func newSelfSignedCertificate(hostnames []string, expiry time.Duration, log *zap.Logger) (*selfSignedCertificate, error) {
+func newSelfSignedCertificate(hostnames []string, expiry time.Duration, log *logrus.Logger) (*selfSignedCertificate, error) {
 	if len(hostnames) <= 0 {
 		return nil, errors.New("no hostnames specified")
 	}

--- a/gatekeeper/server.go
+++ b/gatekeeper/server.go
@@ -80,7 +80,7 @@ func NewProxy(config *Config) (*OAuthProxy, error) {
 	// create the service logger
 	log := createLogger(config)
 
-	log.WithFields(logrus.Fields{"app": prog, "tenantID": "TENANTID"}).Info("starting the service")
+	log.WithFields(logrus.Fields{"app": prog, "tenant": config.TenantID}).Info("starting the service")
 	svc := &OAuthProxy{
 		config:         config,
 		log:            log,

--- a/gatekeeper/server.go
+++ b/gatekeeper/server.go
@@ -127,60 +127,6 @@ func NewProxy(config *Config) (*OAuthProxy, error) {
 	return svc, nil
 }
 
-// TenantHook adds the tenantID to each log entry
-type TenantHook struct {
-	TenantID string
-}
-
-// Levels returns all levels the hook is activate on
-func (h *TenantHook) Levels() []logrus.Level {
-	return logrus.AllLevels
-}
-
-// Fire is trigger on log execution
-func (h *TenantHook) Fire(e *logrus.Entry) error {
-	e.Data["tenantID"] = h.TenantID
-	return nil
-}
-
-// createLogger is responsible for creating the service logger
-func createLogger(config *Config) *logrus.Logger {
-	httplog.SetOutput(ioutil.Discard) // disable the http logger
-
-	logger := &logrus.Logger{
-		Out:       os.Stdout,
-		Formatter: newTextFormatter(),
-		Level:     logrus.DebugLevel,
-	}
-
-	// logger.AddHook(&TenantHook{TenantID: "myTenantID"})
-
-	if config.DisableAllLogging {
-		logger.SetOutput(ioutil.Discard)
-	}
-
-	if config.Verbose {
-		// logger.SetReportCaller(true)
-		logger.Level = logrus.TraceLevel
-	}
-
-	return logger
-}
-
-func newJSONFormatter() *logrus.JSONFormatter {
-	return &logrus.JSONFormatter{
-		TimestampFormat: time.RFC3339Nano,
-	}
-}
-
-func newTextFormatter() *logrus.TextFormatter {
-	return &logrus.TextFormatter{
-		DisableColors:   true,
-		FullTimestamp:   true,
-		TimestampFormat: time.RFC3339Nano,
-	}
-}
-
 // createReverseProxy creates a reverse proxy
 func (r *OAuthProxy) createReverseProxy() error {
 	r.log.WithFields(logrus.Fields{"url": r.config.Upstream}).Info("enabled reverse proxy mode, upstream url")

--- a/gatekeeper/session.go
+++ b/gatekeeper/session.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/gambol99/go-oidc/jose"
-	"go.uber.org/zap"
+	"github.com/sirupsen/logrus"
 )
 
 // getIdentity retrieves the user identity from a request, either from a session cookie or a bearer token
@@ -48,11 +48,12 @@ func (r *OAuthProxy) getIdentity(req *http.Request) (*userContext, error) {
 	}
 	user.bearerToken = isBearer
 
-	r.log.Debug("found the user identity",
-		zap.String("id", user.id),
-		zap.String("name", user.name),
-		zap.String("email", user.email),
-		zap.String("roles", strings.Join(user.roles, ",")))
+	r.log.WithFields(logrus.Fields{
+		"id":    user.id,
+		"name":  user.name,
+		"email": user.email,
+		"roles": strings.Join(user.roles, ","),
+	}).Debug("found the user identity")
 
 	return user, nil
 }

--- a/gatekeeper/stores.go
+++ b/gatekeeper/stores.go
@@ -20,7 +20,6 @@ import (
 	"net/url"
 
 	"github.com/gambol99/go-oidc/jose"
-	"go.uber.org/zap"
 )
 
 // createStorage creates the store client for use
@@ -54,7 +53,7 @@ func (r *OAuthProxy) StoreRefreshToken(token jose.JWT, value string) error {
 	return r.store.Set(getHashKey(&token), value)
 }
 
-// Get retrieves a token from the store, the key we are using here is the access token
+// GetRefreshToken retrieves a token from the store, the key we are using here is the access token
 func (r *OAuthProxy) GetRefreshToken(token jose.JWT) (string, error) {
 	// step: the key is the access token
 	v, err := r.store.Get(getHashKey(&token))
@@ -71,7 +70,7 @@ func (r *OAuthProxy) GetRefreshToken(token jose.JWT) (string, error) {
 // DeleteRefreshToken removes a key from the store
 func (r *OAuthProxy) DeleteRefreshToken(token jose.JWT) error {
 	if err := r.store.Delete(getHashKey(&token)); err != nil {
-		r.log.Error("unable to delete token", zap.Error(err))
+		r.log.WithError(err).Error("unable to delete token")
 
 		return err
 	}
@@ -79,7 +78,7 @@ func (r *OAuthProxy) DeleteRefreshToken(token jose.JWT) error {
 	return nil
 }
 
-// Close is used to close off any resources
+// CloseStore is used to close off any resources
 func (r *OAuthProxy) CloseStore() error {
 	if r.store != nil {
 		return r.store.Close()


### PR DESCRIPTION
This Pull Request:

- Removes uber zap as the application logger and replaces it with logrus.
- Adds a TenantID to application Config struct
- Adds a logrus hook `TenantHook` to append the tenantID in log entry's data fields